### PR TITLE
Use CallExpression instead of Import to work better with other plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   },
   "peerDependencies": {
     "import-inspector": "^2.0.0"
+  },
+  "dependencies": {
+    "babel-plugin-syntax-dynamic-import": "^6.18.0"
   }
 }


### PR DESCRIPTION
This PR proposes that this plugin inherits syntax from babel-plugin-syntax-dynamic-import and uses `CallExpression` instead of `Import` to traverse the tree.

The motivation is that this plugin does not work with other plugins that transform `import(…)` such as [babel-plugin-dynamic-import-node](https://github.com/airbnb/babel-plugin-dynamic-import-node) or [babel-plugin-import-node](https://github.com/LestaD/babel-plugin-import-node) which are required if you want to be able to server render React applications on node.
