### PR TITLE
Only Babel 7 support with @babel/helper-module-imports

### DIFF
--- a/__snapshots__/test.js.snap
+++ b/__snapshots__/test.js.snap
@@ -6,7 +6,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -20,10 +21,13 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _path from \\"path\\";
-import { report as _report } from \\"import-inspector\\";
+var _path = _interopRequireDefault(require(\\"path\\")).default;
+
+var _report = require(\\"import-inspector\\").report;
 
 const _start = Date.now();
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
@@ -41,7 +45,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   importedModulePath: \\"./a\\"
 });
@@ -54,7 +59,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -68,7 +74,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\"
 });
@@ -81,7 +88,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -95,7 +103,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -109,8 +118,12 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import _path from \\"path\\";
-import { report as _report } from \\"import-inspector\\";
+var _path = _interopRequireDefault(require(\\"path\\")).default;
+
+var _report = require(\\"import-inspector\\").report;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\",
@@ -125,7 +138,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -139,7 +153,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\",
@@ -154,7 +169,8 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
+
 _report(import(\\"./a\\"), {
   currentModuleFileName: \\"test.js\\",
   importedModulePath: \\"./a\\"
@@ -168,7 +184,7 @@ import(\\"./a\\")
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { report as _report } from \\"import-inspector\\";
+var _report = require(\\"import-inspector\\").report;
 
 const _start = Date.now();
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const importsHelper = require('@babel/helper-module-imports');
+
 module.exports = function({types: t, template}) {
   function currentModuleFileName(path) {
     return t.objectProperty(
@@ -31,7 +33,7 @@ module.exports = function({types: t, template}) {
 
   function serverSideRequirePath(path) {
     if (!path.hub.file[pathId]) {
-      path.hub.file[pathId] = path.hub.file.addImport('path', 'default', 'path');
+      path.hub.file[pathId] = importsHelper.addDefault(path, 'path', { nameHint: 'path' });
     }
 
     return t.objectProperty(
@@ -90,7 +92,7 @@ module.exports = function({types: t, template}) {
         }, this.opts);
 
         if (!path.hub.file[reportId]) {
-          path.hub.file[reportId] = path.hub.file.addImport('import-inspector', 'report');
+          path.hub.file[reportId] = importsHelper.addNamed(path, 'report', 'import-inspector');
         }
 
         let props = [];

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@babel/helper-module-imports": "^7.0.0-beta.32",
     "babel-plugin-tester": "^3.1.0",
     "babylon-options": "^1.1.2",
     "flow-bin": "^0.48.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@babel/helper-module-imports@^7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.32.tgz#8126fc024107c226879841b973677a4f4e510a03"
+  dependencies:
+    "@babel/types" "7.0.0-beta.32"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.32.tgz#c317d0ecc89297b80bbcb2f50608e31f6452a5ff"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -1850,6 +1865,10 @@ tmpl@1.0.x:
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"


### PR DESCRIPTION
Do not merge! May break babel 6 support.

Only for demo purposes, who want to migrate to Babel 7 scoped packages under `@babel/...`.

Can be installed in such way:
```bash
yarn add https://github.com/nodkz/babel-plugin-import-inspector.git#babel7 --dev
```

